### PR TITLE
(maint) Add support for running specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,36 @@
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
+
+def location_for(place, fake_version = nil)
+  if place =~ /^(git[:@][^#]*)#(.*)/
+    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  else
+    [place, { :require => false }]
+  end
+end
+
+# C Ruby (MRI) or Rubinius, but NOT Windows
+platforms :ruby do
+  gem 'pry', :group => :development
+end
+
+gem "puppet", *location_for(ENV['PUPPET_LOCATION'] || ['> 3.7', '< 5'])
+gem "facter", *location_for(ENV['FACTER_LOCATION'] || ['> 1.6', '< 3'])
+gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '~> 1.0')
+gem "rake", "10.1.1", :require => false
+
+group(:development, :test) do
+  gem "rspec", "~> 2.14.0", :require => false
+
+  # Mocha is not compatible across minor version changes; because of this only
+  # versions matching ~> 0.10.5 are supported. All other versions are unsupported
+  # and can be expected to fail.
+  gem "mocha", "~> 0.10.5", :require => false
+end
+
+if File.exists? "#{__FILE__}.local"
+  eval(File.read("#{__FILE__}.local"), binding)
+end
+
+# vim:filetype=ruby

--- a/spec/fixtures/unit/provider/naginator/define_empty_param
+++ b/spec/fixtures/unit/provider/naginator/define_empty_param
@@ -1,0 +1,6 @@
+# fixture for the spec test for PUP-1041
+
+define host {
+  parents
+  use       linux-server
+}

--- a/spec/lib/puppet_spec/compiler.rb
+++ b/spec/lib/puppet_spec/compiler.rb
@@ -1,0 +1,49 @@
+module PuppetSpec::Compiler
+  module_function
+
+  def compile_to_catalog(string, node = Puppet::Node.new('foonode'))
+    Puppet[:code] = string
+    # see lib/puppet/indirector/catalog/compiler.rb#filter
+    Puppet::Parser::Compiler.compile(node).filter { |r| r.virtual? }
+  end
+
+  def compile_to_ral(manifest)
+    catalog = compile_to_catalog(manifest)
+    ral = catalog.to_ral
+    ral.finalize
+    ral
+  end
+
+  def compile_to_relationship_graph(manifest, prioritizer = Puppet::Graph::SequentialPrioritizer.new)
+    ral = compile_to_ral(manifest)
+    graph = Puppet::Graph::RelationshipGraph.new(prioritizer)
+    graph.populate_from(ral)
+    graph
+  end
+
+  def apply_compiled_manifest(manifest, prioritizer = Puppet::Graph::SequentialPrioritizer.new)
+    catalog = compile_to_ral(manifest)
+    if block_given?
+      catalog.resources.each { |res| yield res }
+    end
+    transaction = Puppet::Transaction.new(catalog,
+                                         Puppet::Transaction::Report.new("apply"),
+                                         prioritizer)
+    transaction.evaluate
+    transaction.report.finalize_report
+
+    transaction
+  end
+
+  def apply_with_error_check(manifest)
+    apply_compiled_manifest(manifest) do |res|
+      res.expects(:err).never
+    end
+  end
+
+  def order_resources_traversed_in(relationships)
+    order_seen = []
+    relationships.traverse { |resource| order_seen << resource.ref }
+    order_seen
+  end
+end

--- a/spec/lib/puppet_spec/database.rb
+++ b/spec/lib/puppet_spec/database.rb
@@ -1,0 +1,29 @@
+# This just makes some nice things available at global scope, and for setup of
+# tests to use a real fake database, rather than a fake stubs-that-don't-work
+# version of the same.  Fun times.
+def sqlite?
+  if $sqlite.nil?
+    begin
+      require 'sqlite3'
+      $sqlite = true
+    rescue LoadError
+      $sqlite = false
+    end
+  end
+  $sqlite
+end
+
+def can_use_scratch_database?
+  sqlite? and Puppet.features.rails?
+end
+
+
+# This is expected to be called in your `before :each` block, and will get you
+# ready to roll with a serious database and all.  Cleanup is handled
+# automatically for you.  Nothing to do there.
+def setup_scratch_database
+  Puppet[:dbadapter] = 'sqlite3'
+  Puppet[:dblocation] = ':memory:'
+  Puppet[:railslog] = PuppetSpec::Files.tmpfile('storeconfigs.log')
+  Puppet::Rails.init
+end

--- a/spec/lib/puppet_spec/files.rb
+++ b/spec/lib/puppet_spec/files.rb
@@ -1,0 +1,88 @@
+require 'fileutils'
+require 'tempfile'
+require 'tmpdir'
+require 'pathname'
+
+# A support module for testing files.
+module PuppetSpec::Files
+  def self.cleanup
+    $global_tempfiles ||= []
+    while path = $global_tempfiles.pop do
+      begin
+        Dir.unstub(:entries)
+        FileUtils.rm_rf path, :secure => true
+      rescue Errno::ENOENT
+        # nothing to do
+      end
+    end
+  end
+
+  def make_absolute(path) PuppetSpec::Files.make_absolute(path) end
+  def self.make_absolute(path)
+    path = File.expand_path(path)
+    path[0] = 'c' if Puppet.features.microsoft_windows?
+    path
+  end
+
+  def tmpfile(name, dir = nil) PuppetSpec::Files.tmpfile(name, dir) end
+  def self.tmpfile(name, dir = nil)
+    # Generate a temporary file, just for the name...
+    source = dir ? Tempfile.new(name, dir) : Tempfile.new(name)
+    path = source.path
+    source.close!
+
+    record_tmp(File.expand_path(path))
+
+    path
+  end
+
+  def file_containing(name, contents) PuppetSpec::Files.file_containing(name, contents) end
+  def self.file_containing(name, contents)
+    file = tmpfile(name)
+    File.open(file, 'wb') { |f| f.write(contents) }
+    file
+  end
+
+  def tmpdir(name) PuppetSpec::Files.tmpdir(name) end
+  def self.tmpdir(name)
+    dir = Dir.mktmpdir(name)
+
+    record_tmp(dir)
+
+    dir
+  end
+
+  def dir_containing(name, contents_hash) PuppetSpec::Files.dir_containing(name, contents_hash) end
+  def self.dir_containing(name, contents_hash)
+    dir_contained_in(tmpdir(name), contents_hash)
+  end
+
+  def self.dir_contained_in(dir, contents_hash)
+    contents_hash.each do |k,v|
+      if v.is_a?(Hash)
+        Dir.mkdir(tmp = File.join(dir,k))
+        dir_contained_in(tmp, v)
+      else
+        file = File.join(dir, k)
+        File.open(file, 'wb') {|f| f.write(v) }
+      end
+    end
+    dir
+  end
+
+  def self.record_tmp(tmp)
+    # ...record it for cleanup,
+    $global_tempfiles ||= []
+    $global_tempfiles << tmp
+  end
+
+  def expect_file_mode(file, mode)
+    actual_mode = "%o" % Puppet::FileSystem.stat(file).mode
+    target_mode = if Puppet.features.microsoft_windows?
+      mode
+    else
+      "10" + "%04i" % mode.to_i
+    end
+    actual_mode.should == target_mode
+  end
+end

--- a/spec/lib/puppet_spec/fixtures.rb
+++ b/spec/lib/puppet_spec/fixtures.rb
@@ -1,0 +1,28 @@
+module PuppetSpec::Fixtures
+  def fixtures(*rest)
+    File.join(PuppetSpec::FIXTURE_DIR, *rest)
+  end
+  def my_fixture_dir
+    callers = caller
+    while line = callers.shift do
+      next unless found = line.match(%r{/spec/(.*)_spec\.rb:})
+      return fixtures(found[1])
+    end
+    fail "sorry, I couldn't work out your path from the caller stack!"
+  end
+  def my_fixture(name)
+    file = File.join(my_fixture_dir, name)
+    unless File.readable? file then
+      fail Puppet::DevError, "fixture '#{name}' for #{my_fixture_dir} is not readable"
+    end
+    return file
+  end
+  def my_fixtures(glob = '*', flags = 0)
+    files = Dir.glob(File.join(my_fixture_dir, glob), flags)
+    unless files.length > 0 then
+      fail Puppet::DevError, "fixture '#{glob}' for #{my_fixture_dir} had no files!"
+    end
+    block_given? and files.each do |file| yield file end
+    files
+  end
+end

--- a/spec/lib/puppet_spec/language.rb
+++ b/spec/lib/puppet_spec/language.rb
@@ -1,0 +1,74 @@
+require 'puppet_spec/compiler'
+require 'matchers/resource'
+
+module PuppetSpec::Language
+  extend RSpec::Matchers::DSL
+
+  def produces(expectations)
+    calledFrom = caller
+    expectations.each do |manifest, resources|
+      it "evaluates #{manifest} to produce #{resources}" do
+        begin
+        case resources
+        when String
+          node = Puppet::Node.new('specification')
+          Puppet[:code] = manifest
+          compiler = Puppet::Parser::Compiler.new(node)
+          evaluator = Puppet::Pops::Parser::EvaluatingParser.new()
+
+          # see lib/puppet/indirector/catalog/compiler.rb#filter
+          catalog = compiler.compile.filter { |r| r.virtual? }
+
+          compiler.send(:instance_variable_set, :@catalog, catalog)
+
+          expect(evaluator.evaluate_string(compiler.topscope, resources)).to eq(true)
+        when Array
+          catalog = PuppetSpec::Compiler.compile_to_catalog(manifest)
+
+          if resources.empty?
+            base_resources = ["Class[Settings]", "Class[main]", "Stage[main]"]
+            expect(catalog.resources.collect(&:ref) - base_resources).to eq([])
+          else
+            resources.each do |reference|
+              if reference.is_a?(Array)
+                matcher = Matchers::Resource.have_resource(reference[0])
+                reference[1].each do |name, value|
+                  matcher = matcher.with_parameter(name, value)
+                end
+              else
+                matcher = Matchers::Resource.have_resource(reference)
+              end
+
+              expect(catalog).to matcher
+            end
+          end
+        else
+          raise "Unsupported creates specification: #{resources.inspect}"
+        end
+      rescue  Puppet::Error, RSpec::Expectations::ExpectationNotMetError => e
+        # provide the backtrace from the caller, or it is close to impossible to find some originators
+        e.set_backtrace(calledFrom)
+        raise
+      end
+
+      end
+    end
+  end
+
+  def fails(expectations)
+    calledFrom = caller
+    expectations.each do |manifest, pattern|
+      it "fails to evaluate #{manifest} with message #{pattern}" do
+        begin
+        expect do
+          PuppetSpec::Compiler.compile_to_catalog(manifest)
+        end.to raise_error(Puppet::Error, pattern)
+        rescue  RSpec::Expectations::ExpectationNotMetError => e
+          # provide the backgrace from the caller, or it is close to impossible to find some originators
+          e.set_backtrace(calledFrom)
+          raise
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/puppet_spec/matchers.rb
+++ b/spec/lib/puppet_spec/matchers.rb
@@ -1,0 +1,152 @@
+require 'stringio'
+
+########################################################################
+# Backward compatibility for Jenkins outdated environment.
+module RSpec
+  module Matchers
+    module BlockAliases
+      alias_method :to,     :should      unless method_defined? :to
+      alias_method :to_not, :should_not  unless method_defined? :to_not
+      alias_method :not_to, :should_not  unless method_defined? :not_to
+    end
+  end
+end
+
+
+########################################################################
+# Custom matchers...
+RSpec::Matchers.define :have_matching_element do |expected|
+  match do |actual|
+    actual.any? { |item| item =~ expected }
+  end
+end
+
+RSpec::Matchers.define :have_matching_log do |expected|
+  match do |actual|
+    actual.map(&:to_s).any? { |item| item =~ expected }
+  end
+end
+
+RSpec::Matchers.define :exit_with do |expected|
+  actual = nil
+  match do |block|
+    begin
+      block.call
+    rescue SystemExit => e
+      actual = e.status
+    end
+    actual and actual == expected
+  end
+  failure_message_for_should do |block|
+    "expected exit with code #{expected} but " +
+      (actual.nil? ? " exit was not called" : "we exited with #{actual} instead")
+  end
+  failure_message_for_should_not do |block|
+    "expected that exit would not be called with #{expected}"
+  end
+  description do
+    "expect exit with #{expected}"
+  end
+end
+
+
+RSpec::Matchers.define :have_printed do |expected|
+
+  case expected
+    when String, Regexp
+      expected = expected
+    else
+      expected = expected.to_s
+  end
+
+  chain :and_exit_with do |code|
+    @expected_exit_code = code
+  end
+
+  define_method :matches_exit_code? do |actual|
+    @expected_exit_code.nil? || @expected_exit_code == actual
+  end
+
+  define_method :matches_output? do |actual|
+    return false unless actual
+    case expected
+      when String
+        actual.include?(expected)
+      when Regexp
+        expected.match(actual)
+      else
+        raise ArgumentError, "No idea how to match a #{actual.class.name}"
+    end
+  end
+
+  match do |block|
+    $stderr = $stdout = StringIO.new
+    $stdout.set_encoding('UTF-8') if $stdout.respond_to?(:set_encoding)
+
+    begin
+      block.call
+    rescue SystemExit => e
+      raise unless @expected_exit_code
+      @actual_exit_code = e.status
+    ensure
+      $stdout.rewind
+      @actual = $stdout.read
+
+      $stdout = STDOUT
+      $stderr = STDERR
+    end
+
+    matches_output?(@actual) && matches_exit_code?(@actual_exit_code)
+  end
+
+  failure_message_for_should do |actual|
+    if actual.nil? then
+      "expected #{expected.inspect}, but nothing was printed"
+    else
+      if !@expected_exit_code.nil? && matches_output?(actual)
+        "expected exit with code #{@expected_exit_code} but " +
+          (@actual_exit_code.nil? ? " exit was not called" : "exited with #{@actual_exit_code} instead")
+      else
+        "expected #{expected.inspect} to be printed; got:\n#{actual}"
+      end
+    end
+  end
+
+  failure_message_for_should_not do |actual|
+    if @expected_exit_code && matches_exit_code?(@actual_exit_code)
+      "expected exit code to not be #{@actual_exit_code}"
+    else
+      "expected #{expected.inspect} to not be printed; got:\n#{actual}"
+    end
+  end
+
+  description do
+    "expect #{expected.inspect} to be printed" + (@expected_exit_code.nil ? '' : " with exit code #{@expected_exit_code}")
+  end
+end
+
+RSpec::Matchers.define :equal_attributes_of do |expected|
+  match do |actual|
+    actual.instance_variables.all? do |attr|
+      actual.instance_variable_get(attr) == expected.instance_variable_get(attr)
+    end
+  end
+end
+
+RSpec::Matchers.define :equal_resource_attributes_of do |expected|
+  match do |actual|
+    actual.keys do |attr|
+      actual[attr] == expected[attr]
+    end
+  end
+end
+
+RSpec::Matchers.define :be_one_of do |*expected|
+  match do |actual|
+    expected.include? actual
+  end
+
+  failure_message_for_should do |actual|
+    "expected #{actual.inspect} to be one of #{expected.map(&:inspect).join(' or ')}"
+  end
+end

--- a/spec/lib/puppet_spec/module_tool/shared_functions.rb
+++ b/spec/lib/puppet_spec/module_tool/shared_functions.rb
@@ -1,0 +1,56 @@
+require 'json'
+
+module PuppetSpec
+  module ModuleTool
+    module SharedFunctions
+      def remote_release(name, version)
+        remote_source.available_releases[name][version]
+      end
+
+      def preinstall(name, version, options = { :into => primary_dir })
+        release = remote_release(name, version)
+        raise "Could not preinstall #{name} v#{version}" if release.nil?
+
+        name = release.name[/-(.*)/, 1]
+        moddir = File.join(options[:into], name)
+        FileUtils.mkdir_p(moddir)
+        File.open(File.join(moddir, 'metadata.json'), 'w') do |file|
+          file.puts(JSON.generate(release.metadata))
+        end
+      end
+
+      def mark_changed(path)
+        app = Puppet::ModuleTool::Applications::Checksummer
+        app.stubs(:run).with(path).returns(['README'])
+      end
+
+      def graph_should_include(name, options)
+        releases = flatten_graph(subject[:graph] || [])
+        release = releases.find { |x| x[:name] == name }
+
+        if options.nil?
+          release.should be_nil
+        else
+          from = options.keys.find { |k| k.nil? || k.is_a?(Semantic::Version) }
+          to   = options.delete(from)
+
+          if to or from
+            options[:previous_version] ||= from
+            options[:version] ||= to
+          end
+
+          release.should_not be_nil
+          release.should include options
+        end
+      end
+
+      def flatten_graph(graph)
+        graph + graph.map { |sub| flatten_graph(sub[:dependencies]) }.flatten
+      end
+
+      def v(str)
+        Semantic::Version.parse(str)
+      end
+    end
+  end
+end

--- a/spec/lib/puppet_spec/module_tool/stub_source.rb
+++ b/spec/lib/puppet_spec/module_tool/stub_source.rb
@@ -1,0 +1,136 @@
+module PuppetSpec
+  module ModuleTool
+    class StubSource < Semantic::Dependency::Source
+      def inspect; "Stub Source"; end
+      def host
+        "http://nowhe.re"
+      end
+
+      def fetch(name)
+        available_releases[name.tr('/', '-')].values
+      end
+
+      def available_releases
+        return @available_releases if defined? @available_releases
+
+        @available_releases = {
+          'puppetlabs-java' => {
+            '10.0.0' => { 'puppetlabs/stdlib' => '4.1.0' },
+          },
+          'puppetlabs-stdlib' => {
+            '4.1.0' => {},
+          },
+          'pmtacceptance-stdlib' => {
+            "4.1.0" => {},
+            "3.2.0" => {},
+            "3.1.0" => {},
+            "3.0.0" => {},
+            "2.6.0" => {},
+            "2.5.1" => {},
+            "2.5.0" => {},
+            "2.4.0" => {},
+            "2.3.2" => {},
+            "2.3.1" => {},
+            "2.3.0" => {},
+            "2.2.1" => {},
+            "2.2.0" => {},
+            "2.1.3" => {},
+            "2.0.0" => {},
+            "1.1.0" => {},
+            "1.0.0" => {},
+          },
+          'pmtacceptance-keystone' => {
+            '3.0.0-rc2' => { "pmtacceptance/mysql" => ">=0.6.1 <1.0.0", "pmtacceptance/stdlib" => ">= 2.5.0" },
+            '3.0.0-rc1' => { "pmtacceptance/mysql" => ">=0.6.1 <1.0.0", "pmtacceptance/stdlib" => ">= 2.5.0" },
+            '2.2.0'     => { "pmtacceptance/mysql" => ">=0.6.1 <1.0.0", "pmtacceptance/stdlib" => ">= 2.5.0" },
+            '2.2.0-rc1' => { "pmtacceptance/mysql" => ">=0.6.1 <1.0.0", "pmtacceptance/stdlib" => ">= 2.5.0" },
+            '2.1.0'     => { "pmtacceptance/mysql" => ">=0.6.1 <1.0.0", "pmtacceptance/stdlib" => ">= 2.5.0" },
+            '2.0.0'     => { "pmtacceptance/mysql" => ">= 0.6.1" },
+            '1.2.0'     => { "pmtacceptance/mysql" => ">= 0.5.0" },
+            '1.1.1'     => { "pmtacceptance/mysql" => ">= 0.5.0" },
+            '1.1.0'     => { "pmtacceptance/mysql" => ">= 0.5.0" },
+            '1.0.1'     => { "pmtacceptance/mysql" => ">= 0.5.0" },
+            '1.0.0'     => { "pmtacceptance/mysql" => ">= 0.5.0" },
+            '0.2.0'     => { "pmtacceptance/mysql" => ">= 0.5.0" },
+            '0.1.0'     => { "pmtacceptance/mysql" => ">= 0.3.0" },
+          },
+          'pmtacceptance-mysql' => {
+            "2.1.0"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "2.0.1"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "2.0.0"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "2.0.0-rc5" => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "2.0.0-rc4" => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "2.0.0-rc3" => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "2.0.0-rc2" => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "2.0.0-rc1" => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "1.0.0"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.9.0"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.8.1"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.8.0"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.7.1"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.7.0"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.6.1"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.6.0"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.5.0"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.4.0"     => {},
+            "0.3.0"     => {},
+            "0.2.0"     => {},
+          },
+          'pmtacceptance-apache' => {
+            "0.10.0"    => { "pmtacceptance/stdlib" => ">= 2.4.0" },
+            "0.9.0"     => { "pmtacceptance/stdlib" => ">= 2.4.0" },
+            "0.8.1"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.8.0"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.7.0"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.6.0"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.5.0-rc1" => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.4.0"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.3.0"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.2.2"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.2.1"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.2.0"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.1.1"     => { "pmtacceptance/stdlib" => ">= 2.2.1" },
+            "0.0.4"     => {},
+            "0.0.3"     => {},
+            "0.0.2"     => {},
+            "0.0.1"     => {},
+          },
+          'pmtacceptance-bacula' => {
+            "0.0.3" => { "pmtacceptance/stdlib" => ">= 2.2.0", "pmtacceptance/mysql" => ">= 1.0.0" },
+            "0.0.2" => { "pmtacceptance/stdlib" => ">= 2.2.0", "pmtacceptance/mysql" => ">= 0.0.1" },
+            "0.0.1" => { "pmtacceptance/stdlib" => ">= 2.2.0" },
+          },
+          'puppetlabs-oneversion' => {
+            "0.0.1" => {}
+          }
+        }
+
+        @available_releases.each do |name, versions|
+          versions.each do |version, deps|
+            deps, metadata = deps.partition { |k,v| k.is_a? String }
+            dependencies = Hash[deps.map { |k, v| [ k.tr('/', '-'), v ] }]
+
+            versions[version] = create_release(name, version, dependencies).tap do |release|
+              release.meta_def(:prepare)     { }
+              release.meta_def(:install)     { |x| @install_dir = x.to_s }
+              release.meta_def(:install_dir) { @install_dir }
+              release.meta_def(:metadata) do
+                metadata = Hash[metadata].merge(
+                  :name         => name,
+                  :version      => version,
+                  :source       => '',   # GRR, Puppet!
+                  :author       => '',   # GRR, Puppet!
+                  :license      => '',   # GRR, Puppet!
+                  :dependencies => dependencies.map do |dep, range|
+                    { :name => dep, :version_requirement => range }
+                  end
+                )
+                Hash[metadata.map { |k,v| [ k.to_s, v ] }]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/puppet_spec/modules.rb
+++ b/spec/lib/puppet_spec/modules.rb
@@ -1,0 +1,26 @@
+module PuppetSpec::Modules
+  class << self
+    def create(name, dir, options = {})
+      module_dir = File.join(dir, name)
+      FileUtils.mkdir_p(module_dir)
+
+      environment = options[:environment]
+
+      if metadata = options[:metadata]
+        metadata[:source]  ||= 'github'
+        metadata[:author]  ||= 'puppetlabs'
+        metadata[:version] ||= '9.9.9'
+        metadata[:license] ||= 'to kill'
+        metadata[:dependencies] ||= []
+
+        metadata[:name] = "#{metadata[:author]}/#{name}"
+
+        File.open(File.join(module_dir, 'metadata.json'), 'w') do |f|
+          f.write(metadata.to_pson)
+        end
+      end
+
+      Puppet::Module.new(name, module_dir, environment)
+    end
+  end
+end

--- a/spec/lib/puppet_spec/pops.rb
+++ b/spec/lib/puppet_spec/pops.rb
@@ -1,0 +1,16 @@
+module PuppetSpec::Pops
+  extend RSpec::Matchers::DSL
+
+  # Checks if an Acceptor has a specific issue in its list of diagnostics
+  matcher :have_issue do |expected|
+    match do |actual|
+      actual.diagnostics.index { |i| i.issue == expected } != nil
+    end
+    failure_message_for_should do |actual|
+      "expected Acceptor[#{actual.diagnostics.collect { |i| i.issue.issue_code }.join(',')}] to contain issue #{expected.issue_code}"
+    end
+    failure_message_for_should_not do |actual|
+      "expected Acceptor[#{actual.diagnostics.collect { |i| i.issue.issue_code }.join(',')}] to not contain issue #{expected.issue_code}"
+    end
+  end
+end

--- a/spec/lib/puppet_spec/scope.rb
+++ b/spec/lib/puppet_spec/scope.rb
@@ -1,0 +1,14 @@
+
+module PuppetSpec::Scope
+  # Initialize a new scope suitable for testing.
+  #
+  def create_test_scope_for_node(node_name)
+    node = Puppet::Node.new(node_name)
+    compiler = Puppet::Parser::Compiler.new(node)
+    scope = Puppet::Parser::Scope.new(compiler)
+    scope.source = Puppet::Resource::Type.new(:node, node_name)
+    scope.parent = compiler.topscope
+    scope
+  end
+
+end

--- a/spec/lib/puppet_spec/settings.rb
+++ b/spec/lib/puppet_spec/settings.rb
@@ -1,0 +1,15 @@
+module PuppetSpec::Settings
+
+  # It would probably be preferable to refactor defaults.rb such that the real definitions of
+  #  these settings were available as a variable, which was then accessible for use during tests.
+  #  However, I'm not doing that yet because I don't want to introduce any additional moving parts
+  #  to this already very large changeset.
+  #  Would be nice to clean this up later.  --cprice 2012-03-20
+  TEST_APP_DEFAULT_DEFINITIONS = {
+    :name         => { :default => "test", :desc => "name" },
+    :logdir       => { :type => :directory, :default => "test", :desc => "logdir" },
+    :confdir      => { :type => :directory, :default => "test", :desc => "confdir" },
+    :vardir       => { :type => :directory, :default => "test", :desc => "vardir" },
+    :rundir       => { :type => :directory, :default => "test", :desc => "rundir" },
+  }
+end

--- a/spec/lib/puppet_spec/verbose.rb
+++ b/spec/lib/puppet_spec/verbose.rb
@@ -1,0 +1,9 @@
+# Support code for running stuff with warnings disabled.
+module Kernel
+  def with_verbose_disabled
+    verbose, $VERBOSE = $VERBOSE, nil
+    result = yield
+    $VERBOSE = verbose
+    return result
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,192 @@
+# NOTE: a lot of the stuff in this file is duplicated in the "puppet_spec_helper" in the project
+#  puppetlabs_spec_helper.  We should probably eat our own dog food and get rid of most of this from here,
+#  and have the puppet core itself use puppetlabs_spec_helper
+
+dir = File.expand_path(File.dirname(__FILE__))
+$LOAD_PATH.unshift File.join(dir, 'lib')
+
+# Don't want puppet getting the command line arguments for rake or autotest
+ARGV.clear
+
+begin
+  require 'rubygems'
+rescue LoadError
+end
+
+require 'puppet'
+gem 'rspec', '>=2.0.0'
+require 'rspec/expectations'
+
+# So everyone else doesn't have to include this base constant.
+module PuppetSpec
+  FIXTURE_DIR = File.join(dir = File.expand_path(File.dirname(__FILE__)), "fixtures") unless defined?(FIXTURE_DIR)
+end
+
+require 'pathname'
+require 'tmpdir'
+require 'fileutils'
+
+require 'puppet_spec/verbose'
+require 'puppet_spec/files'
+require 'puppet_spec/settings'
+require 'puppet_spec/fixtures'
+require 'puppet_spec/matchers'
+require 'puppet_spec/database'
+require 'puppet/test/test_helper'
+
+Pathname.glob("#{dir}/shared_contexts/*.rb") do |file|
+  require file.relative_path_from(Pathname.new(dir))
+end
+
+Pathname.glob("#{dir}/shared_behaviours/**/*.rb") do |behaviour|
+  require behaviour.relative_path_from(Pathname.new(dir))
+end
+
+RSpec.configure do |config|
+  include PuppetSpec::Fixtures
+
+  # Examples or groups can selectively tag themselves as broken.
+  # For example;
+  #
+  # rbv = "#{RUBY_VERSION}-p#{RbConfig::CONFIG['PATCHLEVEL']}"
+  # describe "mostly working", :broken => false unless rbv == "1.9.3-p327" do
+  #  it "parses a valid IP" do
+  #    IPAddr.new("::2:3:4:5:6:7:8")
+  #  end
+  # end
+  exclude_filters = {:broken => true}
+  exclude_filters[:benchmark] = true unless ENV['BENCHMARK']
+  config.filter_run_excluding exclude_filters
+
+  config.mock_with :mocha
+
+  tmpdir = Dir.mktmpdir("rspecrun")
+  oldtmpdir = Dir.tmpdir()
+  ENV['TMPDIR'] = tmpdir
+
+  if Puppet::Util::Platform.windows?
+    config.output_stream = $stdout
+    config.error_stream = $stderr
+
+    config.formatters.each do |f|
+      if not f.instance_variable_get(:@output).kind_of?(::File)
+        f.instance_variable_set(:@output, $stdout)
+      end
+    end
+  end
+
+  Puppet::Test::TestHelper.initialize
+
+  config.before :all do
+    Puppet::Test::TestHelper.before_all_tests()
+    if ENV['PROFILE'] == 'all'
+      require 'ruby-prof'
+      RubyProf.start
+    end
+  end
+
+  config.after :all do
+    if ENV['PROFILE'] == 'all'
+      require 'ruby-prof'
+      result = RubyProf.stop
+      printer = RubyProf::CallTreePrinter.new(result)
+      open(File.join(ENV['PROFILEOUT'],"callgrind.all.#{Time.now.to_i}.trace"), "w") do |f|
+        printer.print(f)
+      end
+    end
+
+    Puppet::Test::TestHelper.after_all_tests()
+  end
+
+  config.before :each do
+    # Disabling garbage collection inside each test, and only running it at
+    # the end of each block, gives us an ~ 15 percent speedup, and more on
+    # some platforms *cough* windows *cough* that are a little slower.
+    GC.disable
+
+    # REVISIT: I think this conceals other bad tests, but I don't have time to
+    # fully diagnose those right now.  When you read this, please come tell me
+    # I suck for letting this float. --daniel 2011-04-21
+    Signal.stubs(:trap)
+
+
+    # TODO: in a more sane world, we'd move this logging redirection into our TestHelper class.
+    #  Without doing so, external projects will all have to roll their own solution for
+    #  redirecting logging, and for validating expected log messages.  However, because the
+    #  current implementation of this involves creating an instance variable "@logs" on
+    #  EVERY SINGLE TEST CLASS, and because there are over 1300 tests that are written to expect
+    #  this instance variable to be available--we can't easily solve this problem right now.
+    #
+    # redirecting logging away from console, because otherwise the test output will be
+    #  obscured by all of the log output
+    @logs = []
+    Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(@logs))
+
+    @log_level = Puppet::Util::Log.level
+
+    base = PuppetSpec::Files.tmpdir('tmp_settings')
+    Puppet[:vardir] = File.join(base, 'var')
+    Puppet[:confdir] = File.join(base, 'etc')
+    Puppet[:logdir] = "$vardir/log"
+    Puppet[:rundir] = "$vardir/run"
+    Puppet[:hiera_config] = File.join(base, 'hiera')
+
+    Puppet::Test::TestHelper.before_each_test()
+  end
+
+  config.after :each do
+    Puppet::Test::TestHelper.after_each_test()
+
+    # TODO: would like to move this into puppetlabs_spec_helper, but there are namespace issues at the moment.
+    PuppetSpec::Files.cleanup
+
+    # TODO: this should be abstracted in the future--see comments above the '@logs' block in the
+    #  "before" code above.
+    #
+    # clean up after the logging changes that we made before each test.
+    @logs.clear
+    Puppet::Util::Log.close_all
+    Puppet::Util::Log.level = @log_level
+
+    # This will perform a GC between tests, but only if actually required.  We
+    # experimented with forcing a GC run, and that was less efficient than
+    # just letting it run all the time.
+    GC.enable
+  end
+
+  config.after :suite do
+    # Log the spec order to a file, but only if the LOG_SPEC_ORDER environment variable is
+    #  set.  This should be enabled on Jenkins runs, as it can be used with Nick L.'s bisect
+    #  script to help identify and debug order-dependent spec failures.
+    if ENV['LOG_SPEC_ORDER']
+      File.open("./spec_order.txt", "w") do |logfile|
+        config.instance_variable_get(:@files_to_run).each { |f| logfile.puts f }
+      end
+    end
+
+    # return to original tmpdir
+    ENV['TMPDIR'] = oldtmpdir
+    FileUtils.rm_rf(tmpdir)
+  end
+
+  if ENV['PROFILE']
+    require 'ruby-prof'
+
+    def profile
+      result = RubyProf.profile { yield }
+      name = example.metadata[:full_description].downcase.gsub(/[^a-z0-9_-]/, "-").gsub(/-+/, "-")
+      printer = RubyProf::CallTreePrinter.new(result)
+      open(File.join(ENV['PROFILEOUT'],"callgrind.#{name}.#{Time.now.to_i}.trace"), "w") do |f|
+        printer.print(f)
+      end
+    end
+
+    config.around(:each) do |example|
+      if ENV['PROFILE'] == 'each' or (example.metadata[:profile] and ENV['PROFILE'])
+        profile { example.run }
+      else
+        example.run
+      end
+    end
+  end
+end


### PR DESCRIPTION
This brings over from the puppet repo bits that allow specs
to work, including:
- spec/fixtures/unit/provider/naginator
- spec/lib/puppet_psec
- spec/spec_helper.rb
- Gemfile

Gemfile was stripped down, but puppet_spec was not so there
is a bunch of stuff in there that is probably not needed.
I.e. more cleanup needed.
